### PR TITLE
openssh: remove "--without-pie" and update to 8.0

### DIFF
--- a/dependencies/openssh.json
+++ b/dependencies/openssh.json
@@ -3,8 +3,8 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-7.9p1.tar.gz",
-            "sha256": "6b4b3ba2253d84ed3771c8050728d597c91cfce898713beb7b64a305b6f11aad"
+            "url": "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.0p1.tar.gz",
+            "sha256": "bd943879e69498e8031eb6b7f44d08cdc37d59a7ab689aa0b437320c3481fd68"
         }
     ]
 }

--- a/dependencies/openssh.json
+++ b/dependencies/openssh.json
@@ -1,6 +1,5 @@
 {
     "name": "openssh",
-    "config-opts": ["--without-pie"],
     "sources": [
         {
             "type": "archive",


### PR DESCRIPTION
PIE is security enhancement. It shouldn't be disabled without specific reason for it.