### PR TITLE
Add --filesystem=~/.var/app/ to complete home dir

### DIFF
--- a/com.borgbase.Vorta.json
+++ b/com.borgbase.Vorta.json
@@ -11,6 +11,7 @@
         "--device=dri",
         "--share=network",
         "--filesystem=host",
+        "--filesystem=~/.var/app/",
         "--own-name=org.kde.*",
         "--talk-name=org.freedesktop.DBus.*",
         "--talk-name=org.freedesktop.Flatpak.*",


### PR DESCRIPTION
Inspired by https://gitlab.gnome.org/World/pika-backup/-/issues/39 fix.

Fixes https://github.com/borgbase/vorta/issues/652