### PR TITLE
Remove forwarding of fd 3 in `fusermount-wrapper.sh`.

### DIFF
--- a/dependencies/fusermount-wrapper.sh
+++ b/dependencies/fusermount-wrapper.sh
@@ -6,4 +6,4 @@ else
     FD_ARGS="--env=_FUSE_COMMFD=${_FUSE_COMMFD} --forward-fd=${_FUSE_COMMFD}"
 fi
 
-exec flatpak-spawn --host --forward-fd=1 --forward-fd=2 --forward-fd=3 $FD_ARGS fusermount "$@"
+exec flatpak-spawn --host $FD_ARGS fusermount "$@"


### PR DESCRIPTION
Forwarding fd 3 sometimes leads to an error because the fd isn't available.
At the same time forwarding fd 3 doesn't seem to be needed as explained in flathub/org.flatpak.Builder#47.
As noted there fd 0, 1 and 2 will always be forwarded so specifying those explicitly isn't needed.

See borgbase/vorta#1424

* dependencies/fusermount-wrapper.sh : Remove args for forwarding fd 1, 2 and 3.