### PR TITLE
Add "x-checker-data" for dependencies

### DIFF
--- a/dependencies/borgbackup.json
+++ b/dependencies/borgbackup.json
@@ -20,8 +20,7 @@
             "sha256": "dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e",
             "x-checker-data": {
                 "type": "pypi",
-                "name": "msgpack",
-                "packagetype": "bdist_wheel"
+                "name": "msgpack"
             }
         },
         {

--- a/dependencies/borgbackup.json
+++ b/dependencies/borgbackup.json
@@ -17,12 +17,22 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/cb/d0/7555686ae7ff5731205df1012ede15dd9d927f6227ea151e901c7406af4f/msgpack-1.1.0.tar.gz",
-            "sha256": "dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e"
+            "sha256": "dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "msgpack",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl",
-            "sha256": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"
+            "url": "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl",
+            "sha256": "29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "packaging",
+                "packagetype": "bdist_wheel"
+            }
         }
     ]
 }

--- a/dependencies/libfuse.json
+++ b/dependencies/libfuse.json
@@ -11,8 +11,15 @@
     "sources": [
         {
             "type": "archive",
-            "url": "https://github.com/libfuse/libfuse/releases/download/fuse-3.16.2/fuse-3.16.2.tar.gz",
-            "sha256": "f797055d9296b275e981f5f62d4e32e089614fc253d1ef2985851025b8a0ce87"
+            "url": "https://github.com/libfuse/libfuse/releases/download/fuse-3.17.2/fuse-3.17.2.tar.gz",
+            "sha256": "3d932431ad94e86179e5265cddde1d67aa3bb2fb09a5bd35c641f86f2b5ed06f",
+            "x-checker-data": {
+                "type": "anitya",
+                "project-id": 861,
+                "stable-only": true,
+                "versions": {"<": "4.0"},
+                "url-template": "https://github.com/libfuse/libfuse/releases/download/fuse-$version/fuse-$version.tar.gz"
+            }
         }
     ]
 }

--- a/dependencies/pyfuse3.json
+++ b/dependencies/pyfuse3.json
@@ -12,18 +12,33 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/89/aa/ab0f7891a01eeb2d2e338ae8fecbe57fcebea1a24dbb64d45801bfab481d/attrs-24.3.0-py3-none-any.whl",
-            "sha256": "ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"
+            "url": "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl",
+            "sha256": "427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "attrs",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl",
-            "sha256": "3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"
+            "url": "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl",
+            "sha256": "4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "exceptiongroup",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl",
-            "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
+            "sha256": "946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "idna",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
@@ -38,7 +53,12 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl",
-            "sha256": "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"
+            "sha256": "2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "sniffio",
+                "packagetype": "bdist_wheel"
+            }
         },
         {
             "type": "file",
@@ -47,8 +67,13 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/b4/04/9954a59e1fb6732f5436225c9af963811d7b24ea62a8bf96991f2cb8c26e/trio-0.28.0-py3-none-any.whl",
-            "sha256": "56d58977acc1635735a96581ec70513cc781b8b6decd299c487d3be2a721cd94"
+            "url": "https://files.pythonhosted.org/packages/69/8e/3f6dfda475ecd940e786defe6df6c500734e686c9cd0a0f8ef6821e9b2f2/trio-0.30.0-py3-none-any.whl",
+            "sha256": "3bf4f06b8decf8d3cf00af85f40a89824669e2d033bb32469d34840edcfc22a5",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "trio",
+                "packagetype": "bdist_wheel"
+            }
         }
     ]
 }

--- a/dependencies/python3-secretstorage.json
+++ b/dependencies/python3-secretstorage.json
@@ -17,16 +17,16 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/ef/82/72403624f197af0db6bac4e58153bc9ac0e6020e57234115db9596eee85d/cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl",
-            "sha256": "f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7",
+            "url": "https://files.pythonhosted.org/packages/35/6e/dca39d553075980ccb631955c47b93d87d27f3596da8d48b1ae81463d915/cryptography-44.0.3-cp39-abi3-manylinux_2_34_x86_64.whl",
+            "sha256": "3bb0847e6363c037df8f6ede57d88eaf3410ca2267fb12275370a76f85786a6f",
             "only-arches": [
                 "x86_64"
             ]
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/a2/cd/2f3c440913d4329ade49b146d74f2e9766422e1732613f57097fea61f344/cryptography-44.0.0-cp39-abi3-manylinux_2_34_aarch64.whl",
-            "sha256": "9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c",
+            "url": "https://files.pythonhosted.org/packages/1b/50/457f6911d36432a8811c3ab8bd5a6090e8d18ce655c22820994913dd06ea/cryptography-44.0.3-cp39-abi3-manylinux_2_34_aarch64.whl",
+            "sha256": "ab0b005721cc0039e885ac3503825661bd9810b15d4f374e473f8c89b7d5460c",
             "only-arches": [
                 "aarch64"
             ]


### PR DESCRIPTION
Hello @Hofer-Julian !
This PR adds `x-checker-data` for maintainable packages.
Also raises glibc from 2.28+ to 2.34+ for `cryptography-44.0.0-cp39-abi3-manylinux_2_28_x86_64.whl`.
Was able to build and run locally.