### PR TITLE
Bump runtime to 6.10

### DIFF
--- a/com.borgbase.Vorta.json
+++ b/com.borgbase.Vorta.json
@@ -1,10 +1,10 @@
 {
     "id": "com.borgbase.Vorta",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.9",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "base": "com.riverbankcomputing.PyQt.BaseApp",
-    "base-version": "6.9",
+    "base-version": "6.10",
     "cleanup-commands": [
         "/app/cleanup-BaseApp.sh"
     ],


### PR DESCRIPTION
6.9s most recent update was in january, we should be using the newer runtime if possible, I have been running vorta for quite a bit with this runtime and nothing seems to have blown up because of it